### PR TITLE
Use Dry for accessing constants

### DIFF
--- a/lib/ios_icon_generator.rb
+++ b/lib/ios_icon_generator.rb
@@ -27,7 +27,7 @@ module IOSIconGenerator
     # @private
     # :nodoc:
     module Commands
-      extend Hanami::CLI::Registry
+      extend Dry::CLI::Registry
     end
   end
 


### PR DESCRIPTION
The error shown:

![Screenshot 2023-04-19 at 11 27 31 AM](https://user-images.githubusercontent.com/19314956/233015888-e2ee0b7d-e9eb-4643-996f-c5c04b521258.png)

From [hanami/cli](https://github.com/hanami/cli) repository:

> NOTE: For versions 0.4 and below, there was a general purpose CLI utility library with this same name. That library has since been renamed to [dry-rb/dry-cli](https://github.com/dry-rb/dry-cli). Please update your Gemfiles accordingly.

The code is outdated, and we need to use `Dry` instead of `Hanami`.

